### PR TITLE
Revert: cosyvoice TTS 세그먼트 분할 제거 (PR #68 이전 상태 복원)

### DIFF
--- a/VoiceCommand/tts/cosyvoice_tts.py
+++ b/VoiceCommand/tts/cosyvoice_tts.py
@@ -18,13 +18,7 @@ from typing import Optional
 import numpy as np
 import pyaudio
 from PySide6.QtCore import QObject, Signal
-from tts.cosyvoice_utils import (
-    _PCMChunkBuffer,
-    _normalize_text_cached,
-    apply_emotion_prosody,
-    inject_breath_cues,
-    split_tts_segments,
-)
+from tts.cosyvoice_utils import _PCMChunkBuffer, _normalize_text_cached, apply_emotion_prosody, inject_breath_cues
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -250,107 +244,105 @@ class CosyVoiceTTS(QObject):
 
     # ── 합성 + 스트리밍 재생 ────────────────────────────────────────────────────
 
-    def _speak_segment(self, text: str) -> bool:
-        if not text:
-            return False
-
-        t0 = time.time()
-
-        self._proc.stdin.write((text.replace("\n", " ").strip() + "\n").encode("utf-8"))
-        self._proc.stdin.flush()
-
-        self._clear_pcm_state()
-
-        def pipe_reader():
-            first = True
-            try:
-                while not self._stopping:
-                    hdr = self._read_exact(4)
-                    if not hdr:
-                        break
-                    size = struct.unpack("<I", hdr)[0]
-                    if size == 0:
-                        break
-                    data = self._read_exact(size)
-                    if not data:
-                        break
-                    if first:
-                        logging.info(f"[TTS] 첫 청크 수신 → 재생 시작: {time.time()-t0:.2f}s")
-                        first = False
-                    max_buffer_bytes = max(self._MAX_PCM_BUFFER_BYTES, len(data))
-                    while not self._stopping:
-                        with self._pcm_lock:
-                            if self._pcm_buffer.size + len(data) <= max_buffer_bytes:
-                                self._pcm_buffer.append(data)
-                                break
-                        time.sleep(0.01)
-            except Exception as e:
-                if not self._stopping:
-                    logging.debug(f"pipe_reader 오류: {e}")
-            finally:
-                self._pcm_done.set()
-
-        reader_t = threading.Thread(target=pipe_reader, daemon=True)
-        reader_t.start()
-
-        pa_stream = self._ensure_stream()
-        if not pa_stream.is_active():
-            pa_stream.start_stream()
-
-        reader_t.join(timeout=300)
-        self._pcm_done.set()
-        deadline = time.time() + 30
-        if pa_stream:
-            while pa_stream.is_active() and time.time() < deadline and not self._stopping:
-                time.sleep(0.1)
-
-        try:
-            if pa_stream:
-                self._close_stream()
-        except Exception:  # nosec B110
-            pass
-        if self._stopping:
-            return False
-
-        logging.info(f"[TTS] 전체 완료: {time.time()-t0:.2f}s")
-
-        ctrl = self._wait_ctrl(timeout=60)
-        if ctrl.startswith("ERROR:"):
-            logging.error(f"워커 오류: {ctrl[6:]}")
-        return not ctrl.startswith("ERROR:")
-
     def speak(self, text: str, emotion: str = "평온") -> bool:
         from audio.audio_manager import _audio_output_lock as _audio_lock
         text = _normalize_text_cached(text or "")
         text = apply_emotion_prosody(text, emotion)
         text = inject_breath_cues(text)
-        segments = split_tts_segments(text)
-        if not segments or self._proc is None or self._proc.poll() is not None:
+        if not text or self._proc is None or self._proc.poll() is not None:
             return False
 
+        # 워커가 아직 준비되지 않았으면 대기 (최대 300초)
         if not self._ready.is_set():
             logging.info("[TTS] 워커 준비 대기 중...")
             if not self._ready.wait(timeout=300):
                 logging.error("[TTS] 워커 준비 타임아웃 — speak() 건너뜀")
                 return False
 
+        # 오디오 장치 사용을 위해 락 획득
         with _audio_lock:
             with self._speak_lock:
-                self.is_playing = True
                 try:
-                    for index, segment in enumerate(segments, start=1):
-                        if len(segments) > 1:
-                            logging.debug("[TTS] 세그먼트 %s/%s: %s", index, len(segments), segment[:30])
-                        if not self._speak_segment(segment):
-                            return False
-                    return True
+                    self.is_playing = True
+                    t0 = time.time()
+
+                    # 워커에 텍스트 전송
+                    self._proc.stdin.write((text.replace("\n", " ").strip() + "\n").encode("utf-8"))
+                    self._proc.stdin.flush()
+
+                    self._clear_pcm_state()
+
+                    def pipe_reader():
+                        first = True
+                        try:
+                            while not self._stopping:
+                                hdr = self._read_exact(4)
+                                if not hdr:
+                                    break
+                                size = struct.unpack("<I", hdr)[0]
+                                if size == 0:
+                                    break
+                                data = self._read_exact(size)
+                                if not data:
+                                    break
+                                if first:
+                                    logging.info(f"[TTS] 첫 청크 수신 → 재생 시작: {time.time()-t0:.2f}s")
+                                    first = False
+                                max_buffer_bytes = max(self._MAX_PCM_BUFFER_BYTES, len(data))
+                                while not self._stopping:
+                                    with self._pcm_lock:
+                                        if self._pcm_buffer.size + len(data) <= max_buffer_bytes:
+                                            self._pcm_buffer.append(data)
+                                            break
+                                    time.sleep(0.01)
+                        except Exception as e:
+                            if not self._stopping:
+                                logging.debug(f"pipe_reader 오류: {e}")
+                        finally:
+                            self._pcm_done.set()
+
+                    reader_t = threading.Thread(target=pipe_reader, daemon=True)
+                    reader_t.start()
+
+                    pa_stream = self._ensure_stream()
+                    if not pa_stream.is_active():
+                        pa_stream.start_stream()
+
+                    # 생성 완료 대기 (최대 300초)
+                    reader_t.join(timeout=300)
+                    # reader가 끝났거나 타임아웃됐어도 완료 플래그를 강제 설정
+                    # → 콜백이 paComplete를 반환할 수 있게 함
+                    self._pcm_done.set()
+                    # 남은 오디오 재생 완료 대기 (드레인 강화)
+                    deadline = time.time() + 30
+                    if pa_stream:
+                        while pa_stream.is_active() and time.time() < deadline and not self._stopping:
+                            time.sleep(0.1)
+
+                    try:
+                        if pa_stream:
+                            self._close_stream()
+                    except Exception:  # nosec B110
+                        pass
+                    if self._stopping:
+                        return False
+
+                    logging.info(f"[TTS] 전체 완료: {time.time()-t0:.2f}s")
+
+                    ctrl = self._wait_ctrl(timeout=60)
+                    if ctrl.startswith("ERROR:"):
+                        logging.error(f"워커 오류: {ctrl[6:]}")
+
+                    self.is_playing = False
+                    self.playback_finished.emit()
+                    return not ctrl.startswith("ERROR:")
+
                 except Exception as e:
                     if not self._stopping:
                         logging.error(f"CosyVoice TTS speak 오류: {e}")
-                    return False
-                finally:
                     self.is_playing = False
                     self.playback_finished.emit()
+                    return False
 
     def _read_exact(self, n: int):
         """stdout에서 정확히 n바이트 읽기"""

--- a/VoiceCommand/tts/cosyvoice_utils.py
+++ b/VoiceCommand/tts/cosyvoice_utils.py
@@ -29,9 +29,6 @@ _BREATH_COMMA_CHARS = ",;:，、"
 _BREATH_MIN_COMPACT_LEN = 22
 _BREATH_MIN_PREFIX_LEN = 8
 _BREATH_MIN_SUFFIX_LEN = 6
-_SEGMENT_MAX_COMPACT_LEN = 28
-_SEGMENT_MIN_PREFIX_LEN = 8
-_SEGMENT_MIN_SUFFIX_LEN = 6
 
 
 _NATIVE_HOURS = [
@@ -175,81 +172,6 @@ def inject_breath_cues(text: str) -> str:
         return normalized
 
     return " ".join(_insert_breath_comma(sentence) for sentence in sentences)
-
-
-def _split_long_segment(sentence: str) -> list[str]:
-    trailing_match = _TRAILING_PUNCT_RE.search(sentence)
-    trailing = trailing_match.group(1) if trailing_match else ""
-    body = sentence[:-len(trailing)] if trailing else sentence
-    body = body.strip()
-    if not body or _compact_len(body) <= _SEGMENT_MAX_COMPACT_LEN:
-        return [sentence.strip()]
-
-    parts = re.split(r"([,;:，、])", body)
-    segments: list[str] = []
-    current = ""
-
-    for idx in range(0, len(parts), 2):
-        clause = parts[idx].strip()
-        punct = parts[idx + 1] if idx + 1 < len(parts) else ""
-        piece = f"{clause}{punct}".strip()
-        if not piece:
-            continue
-
-        candidate = f"{current} {piece}".strip() if current else piece
-        if current and _compact_len(candidate) > _SEGMENT_MAX_COMPACT_LEN:
-            segments.append(current.strip())
-            current = piece
-        else:
-            current = candidate
-
-    if current:
-        segments.append(current.strip())
-
-    if len(segments) == 1:
-        words = body.split()
-        if len(words) < 4:
-            return [sentence.strip()]
-        target = _compact_len(body) / 2
-        best_idx = None
-        best_distance = None
-        for idx in range(1, len(words)):
-            prefix = " ".join(words[:idx])
-            suffix = " ".join(words[idx:])
-            prefix_len = _compact_len(prefix)
-            suffix_len = _compact_len(suffix)
-            if prefix_len < _SEGMENT_MIN_PREFIX_LEN or suffix_len < _SEGMENT_MIN_SUFFIX_LEN:
-                continue
-            distance = abs(prefix_len - target)
-            if best_distance is None or distance < best_distance:
-                best_idx = idx
-                best_distance = distance
-        if best_idx is None:
-            return [sentence.strip()]
-        segments = [
-            " ".join(words[:best_idx]).strip(),
-            " ".join(words[best_idx:]).strip(),
-        ]
-
-    if trailing:
-        segments[-1] = f"{segments[-1]}{trailing}"
-    return [segment for segment in segments if segment]
-
-
-def split_tts_segments(text: str) -> list[str]:
-    """로컬 TTS용 응답을 자연스러운 길이의 세그먼트들로 분할한다."""
-    normalized = _SPACE_RE.sub(" ", text or "").strip()
-    if not normalized:
-        return []
-
-    sentences = _split_with_punctuation(normalized)
-    if not sentences:
-        return [normalized]
-
-    segments: list[str] = []
-    for sentence in sentences:
-        segments.extend(_split_long_segment(sentence))
-    return segments or [normalized]
 
 
 def apply_emotion_prosody(text: str, emotion: str) -> str:


### PR DESCRIPTION
## 변경 내용

- cosyvoice_tts.py: split_tts_segments() / _speak_segment() 제거, PR #68 이전 단일 speak() 구조로 복원
- cosyvoice_utils.py: split_tts_segments 함수 제거
- threads.py: TTSThread._collect_batch() 80ms 배치 처리 유지

## 배경

이슈 #69 첫 문장 음질 저하 수정 4회 시도 모두 실패. 음질 저하 원인이 PR #68에서 추가된 cosyvoice 내부 세그먼트 분할일 가능성이 있어 해당 로직을 제거하고 이전 상태로 복원.

## 테스트 계획

- [ ] 첫 TTS 발화 음질 확인
- [ ] 연속 TTS 배치 처리 정상 동작 확인

Generated with Claude Code