### PR TITLE
Fix: 종료 확인과 긴 TTS 재생 안정화

### DIFF
--- a/VoiceCommand/commands/ai_command.py
+++ b/VoiceCommand/commands/ai_command.py
@@ -750,6 +750,16 @@ class AICommand(BaseCommand):
             })
             return recovered
 
+        if (
+            self._is_shutdown_request(user_text)
+            and self._is_shutdown_confirmation_response(response)
+        ):
+            logging.info(
+                "[AICommand] 종료 확인성 응답으로 판단해 텍스트 기반 도구 복구를 보류: %s",
+                response[:80],
+            )
+            return recovered
+
         if re.search(r'set_timer', response, flags=re.IGNORECASE):
             if self._is_shutdown_request(user_text) and normalized_when:
                 recovered.append({
@@ -831,6 +841,30 @@ class AICommand(BaseCommand):
             return recovered
 
         return recovered
+
+    def _is_shutdown_confirmation_response(self, response: str) -> bool:
+        """종료/전원 차단을 실제 실행하지 않고 사용자 재확인을 요청하는 응답인지 판별."""
+        normalized = re.sub(r"\s+", " ", (response or "").strip()).lower()
+        if not normalized:
+            return False
+
+        shutdown_mentions = (
+            re.search(r"(컴퓨터|시스템|pc|전원).*(종료|꺼|끄)", normalized, flags=re.IGNORECASE)
+            or re.search(r"shutdown", normalized, flags=re.IGNORECASE)
+        )
+        if not shutdown_mentions:
+            return False
+
+        confirmation_patterns = (
+            r"(정말|진짜).*(꺼|끄|종료).*(까요|습니까|\?)",
+            r"(꺼|끄|종료).*(드릴까요|할까요|해도\s*될까요|하시겠습니까|\?)",
+            r"(진행\s*중인\s*작업|저장\s*안|중단됩니다).*(정말|꺼드릴까요|종료할까요|\?)",
+            r"(확인|괜찮|준비).*(되면|되셨으면|말씀|답|확인)",
+        )
+        return any(
+            re.search(pattern, normalized, flags=re.IGNORECASE)
+            for pattern in confirmation_patterns
+        )
 
     def _extract_schedule_phrase(self, text: str) -> str:
         normalized = (text or "").strip()

--- a/VoiceCommand/commands/ai_command.py
+++ b/VoiceCommand/commands/ai_command.py
@@ -48,7 +48,16 @@ class AICommand(BaseCommand):
         "안녕", "고마워", "감사", "잘자", "반가", "미안", "사랑", "농담",
         "몇 시", "시간", "날씨", "볼륨", "음악", "노래", "타이머",
     )
-    _SHUTDOWN_KEYWORDS = ("컴퓨터", "pc", "시스템", "윈도우")
+    _SHUTDOWN_TARGET_KEYWORDS = (
+        "컴퓨터", "시스템", "윈도우", "전원",
+        "computer", "pc", "system", "windows", "machine", "power",
+        "コンピューター", "コンピュータ", "パソコン", "システム", "電源",
+    )
+    _SHUTDOWN_ACTION_KEYWORDS = (
+        "종료", "꺼", "끄",
+        "shutdown", "shut down", "turn off", "power off",
+        "シャットダウン", "終了", "オフ", "切",
+    )
     _SCHEDULE_PATTERN_STRINGS = (
         # 복합 상대 시간 (순서 중요: 긴 표현을 먼저 매칭)
         r'(\d+\s*시간\s*\d+\s*분\s*\d+\s*초\s*(?:후|뒤))',
@@ -793,7 +802,7 @@ class AICommand(BaseCommand):
             })
             return recovered
 
-        if re.search(r'(컴퓨터|시스템|pc).*(종료|꺼)', response, flags=re.IGNORECASE) or re.search(r'shutdown', response, flags=re.IGNORECASE):
+        if self._contains_shutdown_reference(response):
             if normalized_when:
                 recovered.append({
                     "id": "ai_command_recover_1",
@@ -848,11 +857,7 @@ class AICommand(BaseCommand):
         if not normalized:
             return False
 
-        shutdown_mentions = (
-            re.search(r"(컴퓨터|시스템|pc|전원).*(종료|꺼|끄)", normalized, flags=re.IGNORECASE)
-            or re.search(r"shutdown", normalized, flags=re.IGNORECASE)
-        )
-        if not shutdown_mentions:
+        if not self._contains_shutdown_reference(normalized):
             return False
 
         confirmation_patterns = (
@@ -860,11 +865,34 @@ class AICommand(BaseCommand):
             r"(꺼|끄|종료).*(드릴까요|할까요|해도\s*될까요|하시겠습니까|\?)",
             r"(진행\s*중인\s*작업|저장\s*안|중단됩니다).*(정말|꺼드릴까요|종료할까요|\?)",
             r"(확인|괜찮|준비).*(되면|되셨으면|말씀|답|확인)",
+            r"(are\s+you\s+sure|really|confirm|confirmation|do\s+you\s+want|would\s+you\s+like).*(shutdown|shut\s*down|shut\s+it\s+down|shutting\s+down|turn\s+off|power\s+off)",
+            r"(shutdown|shut\s*down|shut\s+it\s+down|shutting\s+down|turn\s+off|power\s+off).*(are\s+you\s+sure|really|confirm|confirmation|do\s+you\s+want|would\s+you\s+like|\?)",
+            r"(unsaved|ongoing|in\s+progress|running\s+work|current\s+work).*(stop|interrupt|terminate|close|lost|shutdown|shut\s*down|shut\s+it\s+down|shutting\s+down|\?)",
+            r"(本当に|確認|よろしい).*(終了|シャットダウン|オフ).*(か|？|\?)",
+            r"(終了|シャットダウン|オフ).*(しますか|してもよろしい|よろしいですか|か|？|\?)",
+            r"(保存していない|作業中|進行中|中断).*(本当に|終了しますか|シャットダウンしますか|？|\?)",
         )
         return any(
             re.search(pattern, normalized, flags=re.IGNORECASE)
             for pattern in confirmation_patterns
         )
+
+    def _contains_shutdown_reference(self, text: str) -> bool:
+        """한국어/영어/일본어 종료·전원 차단 언급을 보수적으로 감지한다."""
+        normalized = re.sub(r"\s+", " ", (text or "").strip()).lower()
+        if not normalized:
+            return False
+        if "shutdown_computer" in normalized:
+            return True
+        if re.search(
+            r"\bshutdown\b|\bshut\s+down\b|\bshut\s+it\s+down\b|\bshutting\s+down\b",
+            normalized,
+            flags=re.IGNORECASE,
+        ):
+            return True
+        has_target = any(token.lower() in normalized for token in self._SHUTDOWN_TARGET_KEYWORDS)
+        has_action = any(token.lower() in normalized for token in self._SHUTDOWN_ACTION_KEYWORDS)
+        return has_target and has_action
 
     def _extract_schedule_phrase(self, text: str) -> str:
         normalized = (text or "").strip()
@@ -877,11 +905,7 @@ class AICommand(BaseCommand):
         return ""
 
     def _is_shutdown_request(self, text: str) -> bool:
-        lowered = (text or "").lower()
-        return (
-            any(token in lowered for token in self._SHUTDOWN_KEYWORDS)
-            and ("종료" in text or "꺼" in text)
-        )
+        return self._contains_shutdown_reference(text)
 
     def _extract_timer_args_from_response(self, response: str) -> Optional[dict]:
         match = re.search(

--- a/VoiceCommand/tests/test_ai_command.py
+++ b/VoiceCommand/tests/test_ai_command.py
@@ -333,12 +333,55 @@ class AICommandTests(unittest.TestCase):
 
         self.assertEqual(recovered, [])
 
+    def test_shutdown_recovery_skips_english_confirmation_question_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "turn off the computer",
+            "Shutting down the computer will stop ongoing work. "
+            "Are you sure you want me to shut it down?",
+        )
+
+        self.assertEqual(recovered, [])
+
+    def test_shutdown_recovery_skips_japanese_confirmation_question_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "コンピューターを終了して",
+            "コンピューターをシャットダウンすると作業が中断されます。本当に終了しますか？",
+        )
+
+        self.assertEqual(recovered, [])
+
     def test_shutdown_recovery_allows_execution_statement_response(self):
         command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
 
         recovered = command._recover_tool_calls_from_response(
             "컴퓨터 꺼줘",
             "컴퓨터를 종료합니다. 잠시만 기다려 주세요.",
+        )
+
+        self.assertEqual(recovered[0]["name"], "shutdown_computer")
+        self.assertTrue(recovered[0]["arguments"]["confirmed"])
+
+    def test_shutdown_recovery_allows_english_execution_statement_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "turn off the computer",
+            "Shutting down the computer. Please wait a moment.",
+        )
+
+        self.assertEqual(recovered[0]["name"], "shutdown_computer")
+        self.assertTrue(recovered[0]["arguments"]["confirmed"])
+
+    def test_shutdown_recovery_allows_japanese_execution_statement_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "コンピューターを終了して",
+            "コンピューターを終了します。少々お待ちください。",
         )
 
         self.assertEqual(recovered[0]["name"], "shutdown_computer")

--- a/VoiceCommand/tests/test_ai_command.py
+++ b/VoiceCommand/tests/test_ai_command.py
@@ -312,6 +312,38 @@ class AICommandTests(unittest.TestCase):
         self.assertEqual(recovered[0]["name"], "schedule_task")
         self.assertEqual(recovered[0]["arguments"]["when"], "5분 뒤")
 
+    def test_shutdown_recovery_skips_confirmation_question_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "컴퓨터 꺼줘",
+            "(진지) 지금 컴퓨터를 종료하면 진행 중인 작업이 모두 중단됩니다. "
+            "혹시 저장 안 한 코드나 작업이 있으신가요? 정말 꺼드릴까요?",
+        )
+
+        self.assertEqual(recovered, [])
+
+    def test_shutdown_recovery_skips_delayed_confirmation_question_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "5분 뒤에 컴퓨터 꺼줘",
+            "5분 뒤에 컴퓨터를 종료하면 진행 중인 작업이 중단됩니다. 정말 종료할까요?",
+        )
+
+        self.assertEqual(recovered, [])
+
+    def test_shutdown_recovery_allows_execution_statement_response(self):
+        command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
+
+        recovered = command._recover_tool_calls_from_response(
+            "컴퓨터 꺼줘",
+            "컴퓨터를 종료합니다. 잠시만 기다려 주세요.",
+        )
+
+        self.assertEqual(recovered[0]["name"], "shutdown_computer")
+        self.assertTrue(recovered[0]["arguments"]["confirmed"])
+
     def test_shutdown_recovery_treats_relative_e_phrase_as_delayed_schedule(self):
         command = AICommand(_FakeAssistant(), lambda msg: None, {"enabled": False})
 

--- a/VoiceCommand/tests/test_fish_tts_ws.py
+++ b/VoiceCommand/tests/test_fish_tts_ws.py
@@ -1,0 +1,31 @@
+import unittest
+
+from tts.fish_tts_ws import (
+    _estimate_pcm_duration_seconds,
+    _playback_join_timeout,
+)
+
+
+class FishTTSWebSocketTests(unittest.TestCase):
+    def test_estimate_pcm_duration_seconds_from_wav_params(self):
+        duration = _estimate_pcm_duration_seconds(
+            frame_bytes=3_308_630,
+            sample_rate=44_100,
+            channels=1,
+            sample_width=2,
+        )
+
+        self.assertAlmostEqual(duration, 37.5, places=1)
+
+    def test_playback_join_timeout_scales_with_long_audio_duration(self):
+        timeout = _playback_join_timeout(37.5)
+
+        self.assertGreater(timeout, 37.5)
+        self.assertGreater(timeout, 30.0)
+
+    def test_playback_join_timeout_keeps_short_audio_floor(self):
+        self.assertEqual(_playback_join_timeout(3.0), 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/VoiceCommand/tts/fish_tts_ws.py
+++ b/VoiceCommand/tts/fish_tts_ws.py
@@ -16,6 +16,10 @@ from PySide6.QtCore import QObject, Signal
 class FishTTSWebSocket(QObject):
     playback_finished = Signal()
     _QUEUE_MAX_CHUNKS = 64
+    _MIN_PLAYBACK_JOIN_TIMEOUT_SEC = 30.0
+    _PLAYBACK_TIMEOUT_GRACE_RATIO = 0.15
+    _PLAYBACK_TIMEOUT_GRACE_MIN_SEC = 5.0
+    _PLAYBACK_TIMEOUT_MAX_SEC = 900.0
 
     def __init__(self, api_key="", reference_id=""):
         super().__init__()
@@ -52,6 +56,8 @@ class FishTTSWebSocket(QObject):
             self.stop_event.clear()
             stop_event = self.stop_event
             download_done = threading.Event()
+            metadata_ready = threading.Event()
+            playback_meta = {"duration_sec": 0.0}
 
             def play_worker():
                 # 1단계: 전체 WAV 수집
@@ -71,6 +77,7 @@ class FishTTSWebSocket(QObject):
 
                 wav_bytes = buf.getvalue()
                 if not wav_bytes:
+                    metadata_ready.set()
                     return
 
                 # 2단계: wave 모듈로 파싱
@@ -80,11 +87,21 @@ class FishTTSWebSocket(QObject):
                         sample_width = wf.getsampwidth()
                         sample_rate = wf.getframerate()
                         frames = wf.readframes(wf.getnframes())
+                    duration_sec = _estimate_pcm_duration_seconds(
+                        len(frames),
+                        sample_rate,
+                        channels,
+                        sample_width,
+                    )
+                    playback_meta["duration_sec"] = duration_sec
+                    metadata_ready.set()
                     logging.info(
                         f"[TTS] WAV 파라미터: {sample_rate}Hz {channels}ch "
-                        f"{sample_width * 8}bit / {len(frames)} bytes"
+                        f"{sample_width * 8}bit / {len(frames)} bytes "
+                        f"({duration_sec:.1f}s)"
                     )
                 except Exception as exc:
+                    metadata_ready.set()
                     logging.error(f"WAV 파싱 실패: {exc}")
                     return
 
@@ -147,9 +164,17 @@ class FishTTSWebSocket(QObject):
             audio_queue.put(None)
             logging.debug(f"다운로드 완료 ({chunk_count}개 청크)")
 
-            self.play_thread.join(timeout=30.0)
+            metadata_ready.wait(timeout=5.0)
+            playback_timeout = _playback_join_timeout(
+                playback_meta.get("duration_sec", 0.0)
+            )
+            self.play_thread.join(timeout=playback_timeout)
             if self.play_thread.is_alive():
-                logging.warning("재생 스레드 타임아웃 — 강제 중단")
+                logging.warning(
+                    "재생 스레드 타임아웃 — 강제 중단 (예상 재생 %.1fs, 대기 %.1fs)",
+                    playback_meta.get("duration_sec", 0.0),
+                    playback_timeout,
+                )
                 self.stop_event.set()
                 self.play_thread.join(timeout=2.0)
 
@@ -175,3 +200,28 @@ class FishTTSWebSocket(QObject):
 
     def __del__(self):
         pass
+
+
+def _estimate_pcm_duration_seconds(
+    frame_bytes: int,
+    sample_rate: int,
+    channels: int,
+    sample_width: int,
+) -> float:
+    bytes_per_second = sample_rate * channels * sample_width
+    if bytes_per_second <= 0:
+        return 0.0
+    return max(0.0, frame_bytes / bytes_per_second)
+
+
+def _playback_join_timeout(duration_sec: float) -> float:
+    if duration_sec <= 0:
+        return FishTTSWebSocket._MIN_PLAYBACK_JOIN_TIMEOUT_SEC
+
+    grace_sec = max(
+        FishTTSWebSocket._PLAYBACK_TIMEOUT_GRACE_MIN_SEC,
+        duration_sec * FishTTSWebSocket._PLAYBACK_TIMEOUT_GRACE_RATIO,
+    )
+    timeout = duration_sec + grace_sec
+    timeout = max(timeout, FishTTSWebSocket._MIN_PLAYBACK_JOIN_TIMEOUT_SEC)
+    return min(timeout, FishTTSWebSocket._PLAYBACK_TIMEOUT_MAX_SEC)


### PR DESCRIPTION
- 종료/전원 차단 확인 질문을 실제 실행 신호로 오판하지 않도록 텍스트 기반 도구 복구를 보강했습니다.
- 한국어, 영어, 일본어 확인 질문과 실행문을 구분하는 회귀 테스트를 추가했습니다.
- Fish Audio 장문 WAV 재생 시간을 계산해 30초 고정 타임아웃으로 TTS가 중간에 끊기지 않도록 개선했습니다.
- 검증: pytest VoiceCommand\tests 371 passed
- 검증: VoiceCommand\validate_repo.py --compile-only 통과
- Closes #93